### PR TITLE
Allow running notebooks in this repo using a BinderHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # 2nwb
 a collection of scripts for converting datasets to NWB
+
+Click the button below to launch the write_ephys.ipynb Jupyter notebook as a cloud-hosted 'Binder'
+
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/bendichter/to_nwb/master?filepath=ephys_tutorial%2Fwrite_ephys.ipynb)

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,20 +1,12 @@
-# Because binder is starting from a stripped-down docker, we don't need to worry
-# about forcing upgrade with -U (since pynwb won't already be installed)
+# pin version of pynwb (pulled from PyPI; pip will handle dependencies)
+pynwb=0.3.0
 
-# point to specific pre-release commit (so that Binder won't break unexpectedly with dev changes). 
-# Can't use a tag like 'latest', since Binder won't know to rebuild when it changes (and will cache 
-# last build)
--e git+https://github.com/NeurodataWithoutBorders/pynwb.git@8e60520#egg=pynwb # 0.3.0.post0.dev2
+# Should we need to specify a pre-release version of pynwb:
+## Point to specific pre-release commit (so that Binder won't break unexpectedly with dev changes). 
+## NB: Even if we wanted bleeding edge of 'dev' branch, we can't use a link to a tag like 'latest', 
+## since Binder won't know to rebuild when it changes.
+#-e git+https://github.com/NeurodataWithoutBorders/pynwb.git@8e60520cbc225e2e0379545087e5ce937637736d#egg=pynwb-0.3.0.post0.dev2
 
-# Must specify a version including dev string to get pre-release versions
-# [Note do not use '--no-index', or else pip won't be able to install the requirements
-# specified by pynwb]
-#-f https://github.com/NeurodataWithoutBorders/pynwb/releases/tag/latest
-#pynwb>=0.0.dev0
-
-# download a specific release (but might as well use PyPI in this case, since our releases 
-# are automatically pushed there.
-#https://github.com/NeurodataWithoutBorders/pynwb/releases/download/0.3.0/pynwb-0.3.0.tar.gz
-
+# reqs for ephys_tutorial/write_ephys.ipynb
 datetime
 numpy

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,5 @@
 # pin version of pynwb (pulled from PyPI; pip will handle dependencies)
-pynwb=0.3.0
+pynwb==0.3.0
 
 # Should we need to specify a pre-release version of pynwb:
 ## Point to specific pre-release commit (so that Binder won't break unexpectedly with dev changes). 

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,20 @@
+# Because binder is starting from a stripped-down docker, we don't need to worry
+# about forcing upgrade with -U (since pynwb won't already be installed)
+
+# point to specific pre-release commit (so that Binder won't break unexpectedly with dev changes). 
+# Can't use a tag like 'latest', since Binder won't know to rebuild when it changes (and will cache 
+# last build)
+-e git+https://github.com/NeurodataWithoutBorders/pynwb.git@8e60520#egg=pynwb # 0.3.0.post0.dev2
+
+# Must specify a version including dev string to get pre-release versions
+# [Note do not use '--no-index', or else pip won't be able to install the requirements
+# specified by pynwb]
+#-f https://github.com/NeurodataWithoutBorders/pynwb/releases/tag/latest
+#pynwb>=0.0.dev0
+
+# download a specific release (but might as well use PyPI in this case, since our releases 
+# are automatically pushed there.
+#https://github.com/NeurodataWithoutBorders/pynwb/releases/download/0.3.0/pynwb-0.3.0.tar.gz
+
+datetime
+numpy

--- a/ephys_tutorial/write_ephys.ipynb
+++ b/ephys_tutorial/write_ephys.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pynwb import NWBFile\n",
+    "from datetime import datetime\n",
+    "import numpy as np\n",
+    "\n",
+    "nwbfile = NWBFile(source='path of data in old format',  # required\n",
+    "                  session_description='mouse in open exploration and theta maze',  # required\n",
+    "                  identifier='id',  # required\n",
+    "                  session_start_time=datetime(2017, 5, 4, 1, 1, 1),  # required\n",
+    "                  file_create_date=datetime.now(),  # optional\n",
+    "                  experimenter='My Name',  # optional\n",
+    "                  session_id='session_id',  # optional\n",
+    "                  institution='University of My Institution',  # optional\n",
+    "                  lab='My Lab Name',  # optional\n",
+    "                  related_publications='DOI:10.1016/j.neuron.2016.12.011',  # optional\n",
+    "                  )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shank_channels = [[0, 1, 2, 3], [0, 1, 2]]\n",
+    "\n",
+    "electrode_counter = 0\n",
+    "for shankn, channels in enumerate(shank_channels):\n",
+    "    device_name = 'shank{}'.format(shankn)\n",
+    "    device = nwbfile.create_device(device_name, 'source')\n",
+    "    electrode_group = nwbfile.create_electrode_group(\n",
+    "        name=device_name + '_electrodes',\n",
+    "        source='source',\n",
+    "        description=device_name,\n",
+    "        device=device,\n",
+    "        location='brain area')\n",
+    "    for channel in channels:\n",
+    "        nwbfile.add_electrode(electrode_counter,\n",
+    "                              5.3, 1.5, 8.5,  # position\n",
+    "                              imp=np.nan,\n",
+    "                              location='unknown',\n",
+    "                              filtering='unknown',\n",
+    "                              description='electrode {} of shank {}, channel {}'.format(\n",
+    "                                  electrode_counter, shankn, channel),\n",
+    "                              group=electrode_group)\n",
+    "        electrode_counter += 1\n",
+    "all_table_region = nwbfile.create_electrode_table_region(\n",
+    "    list(range(electrode_counter)), 'all electrodes')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pynwb.ecephys import ElectricalSeries, LFP\n",
+    "\n",
+    "lfp_data = np.random.randn(100, 7)\n",
+    "\n",
+    "all_lfp = nwbfile.add_acquisition(\n",
+    "    LFP('source',\n",
+    "        ElectricalSeries('name', 'source',\n",
+    "            lfp_data, all_table_region,\n",
+    "            starting_time=0.0, rate=1000.,  # Hz\n",
+    "            resolution=.001,\n",
+    "            conversion=1., unit='V')\n",
+    "        )\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pynwb.misc import UnitTimes\n",
+    "\n",
+    "# gen spiking data\n",
+    "all_spikes = []\n",
+    "for unit in range(20):\n",
+    "    n_spikes = np.random.poisson(lam=10)\n",
+    "    all_spikes.append(np.random.randn(n_spikes))\n",
+    "\n",
+    "# write UnitTimes object\n",
+    "ut = UnitTimes(name='name', source='source')\n",
+    "for i, unit_spikes in enumerate(all_spikes):\n",
+    "    ut.add_spike_times(i, unit_spikes)\n",
+    "\n",
+    "spiking_module = nwbfile.create_processing_module(name='spikes',\n",
+    "    source='source', description='data relevant to spiking')\n",
+    "\n",
+    "spiking_module.add_container(ut)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pynwb.behavior import SpatialSeries, Position\n",
+    "\n",
+    "position_data = np.array([np.linspace(0, 10,100),\n",
+    "                          np.linspace(1, 8, 100)]).T\n",
+    "tt_position = np.linspace(0, 100) / 200\n",
+    "\n",
+    "spatial_series_object = SpatialSeries(name='name', source='source',\n",
+    "                                      data=position_data,\n",
+    "                                      reference_frame='unknown',\n",
+    "                                      conversion=np.nan,\n",
+    "                                      resolution=np.nan,\n",
+    "                                      timestamps=tt_position)\n",
+    "pos_obj = Position(source='source', spatial_series=spatial_series_object,\n",
+    "                   name='name')\n",
+    "behavior_module = nwbfile.create_processing_module(name='behavior',\n",
+    "    source='source', description='data relevant to behavior')\n",
+    "\n",
+    "behavior_module.add_container(pos_obj)\n",
+    "\n",
+    "###\n",
+    "\n",
+    "from pynwb.file import Subject\n",
+    "\n",
+    "nwbfile.subject = Subject(age='9 months', description='description',\n",
+    "        species='rat', genotype='genotype', sex='M', source='source')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pynwb import NWBHDF5IO\n",
+    "\n",
+    "with NWBHDF5IO('test_ephys.nwb', mode='w') as io:\n",
+    "    io.write(nwbfile)\n",
+    "\n",
+    "with NWBHDF5IO('test_ephys.nwb', mode='r') as io:\n",
+    "    nwbfile = io.read()\n",
+    "\n",
+    "    print(nwbfile.acquisition['LFP']['electrical_series'].data.shape)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [default]",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION

You can test the resulting Binder at:
https://mybinder.org/v2/gh/tjd2002/to_nwb/binderify-pull?filepath=ephys_tutorial%2Fwrite_ephys.ipynb

- I added the requirements.txt to the 'binder' subdir (rather than to a project-level 'requirements.txt') since there may be Binder-specific tweaks, and since I didn't make any effort to identify all the requirements of the repo (just those needed for the write_epyhs notebook for now.
- I think we want to point Binder to a specific pre-release commit of pynwb, so that the demo can run on pre-release code, but doesn't break when someone pushes a change to the dev branch. 
- We will need to manually update pynwb for use in the Binder. (This may be a good thing--if we instead pointed Binder at the 'latest' tag, then I don't think Binder would pick up the changes in pynwb, so we'd be serving stale versions of pynwb anyway  [at least until we made an unrelated change to the to_nwb repo, in which case we'd trigger an unanticipated pynwb upgrade]).
- The `write_ephys.ipynwb` is just the same code as in write_ephys.py, but broken up into cells.

The button in the README points to the upstream repo (bendichter/to_nwb), so won't work until after the merge is accepted. 