### PR TITLE
Replacing soup with lxml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,4 @@ setup(
     author_email='ben.dichter@gmail.com',
     keywords='nwb',
     packages=find_packages(),
-    install_requires=['hdmf','scipy', 'pynwb', 'tqdm', 'bs4', 'pandas', 'numpy', 'h5py', 'xlrd', 'lxml'])
+    install_requires=['hdmf', 'scipy', 'pynwb', 'tqdm', 'pandas', 'numpy', 'h5py', 'xlrd', 'lxml'])


### PR DESCRIPTION
In response to `nwb-converion-tools` [issue #58](https://github.com/catalystneuro/nwb-conversion-tools/issues/58), as well as the reversion of module reliance back to `to_nwb`, I'll be going through these helper functions and replacing usage of soup with direct lxml access. I'll post again later when all the changes are complete.